### PR TITLE
feat: add ATR risk-managed MT5 trading orchestration

### DIFF
--- a/broker.py
+++ b/broker.py
@@ -1,0 +1,326 @@
+"""Broker execution utilities for MetaTrader 5."""
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+import MetaTrader5 as mt5
+
+
+logger = logging.getLogger(__name__)
+
+
+def _snap_to_step(volume: float, step: float) -> float:
+    step = max(step, 1e-8)
+    snapped = round(volume / step) * step
+    return max(0.0, snapped)
+
+
+def _round_volume(symbol_info, volume: float) -> float:
+    """Round the requested volume to the nearest legal lot size."""
+    volume = max(symbol_info.volume_min, min(symbol_info.volume_max, volume))
+    volume = _snap_to_step(volume, symbol_info.volume_step)
+    precision = getattr(symbol_info, "volume_precision", 2)
+    return round(volume, precision)
+
+
+def make_legal_sl_tp(
+    direction: str,
+    entry_price: float,
+    sl_price: float,
+    tp_price: float,
+    symbol: str,
+) -> Tuple[float, float]:
+    """Adjust stop-loss / take-profit to respect symbol stop and freeze levels."""
+    si = mt5.symbol_info(symbol)
+    if si is None:
+        raise RuntimeError(f"Symbol info unavailable for {symbol}")
+
+    tick = mt5.symbol_info_tick(symbol)
+    if tick is None:
+        raise RuntimeError(f"Symbol tick unavailable for {symbol}")
+
+    digits = si.digits
+    point = si.point
+    stops = getattr(si, "trade_stops_level", 0) * point
+    freeze = getattr(si, "trade_freeze_level", 0) * point
+
+    bid = float(tick.bid)
+    ask = float(tick.ask)
+
+    buffer = point
+    if direction.upper() == "LONG":
+        min_sl = bid - stops - buffer
+        if sl_price > min_sl:
+            logger.info(
+                "[BROKER] SL adjusted for stops level (long): target=%.5f adjusted=%.5f",
+                sl_price,
+                min_sl,
+            )
+            sl_price = min_sl
+        min_tp = ask + stops + buffer
+        if tp_price < min_tp:
+            logger.info(
+                "[BROKER] TP adjusted for stops level (long): target=%.5f adjusted=%.5f",
+                tp_price,
+                min_tp,
+            )
+            tp_price = min_tp
+    else:
+        min_sl = ask + stops + buffer
+        if sl_price < min_sl:
+            logger.info(
+                "[BROKER] SL adjusted for stops level (short): target=%.5f adjusted=%.5f",
+                sl_price,
+                min_sl,
+            )
+            sl_price = min_sl
+        min_tp = bid - stops - buffer
+        if tp_price > min_tp:
+            logger.info(
+                "[BROKER] TP adjusted for stops level (short): target=%.5f adjusted=%.5f",
+                tp_price,
+                min_tp,
+            )
+            tp_price = min_tp
+
+    def _normalize(price: float) -> float:
+        factor = 10 ** digits
+        return int(price * factor + 0.5) / factor
+
+    sl_price = _normalize(sl_price)
+    tp_price = _normalize(tp_price)
+
+    # Respect freeze level: ensure distance is outside freeze, otherwise defer a tick away.
+    if direction.upper() == "LONG":
+        freeze_floor = bid - freeze - buffer
+        if sl_price > freeze_floor:
+            logger.info(
+                "[BROKER] SL within freeze zone (long). Deferring to %.5f",
+                freeze_floor,
+            )
+            sl_price = _normalize(freeze_floor)
+    else:
+        freeze_ceiling = ask + freeze + buffer
+        if sl_price < freeze_ceiling:
+            logger.info(
+                "[BROKER] SL within freeze zone (short). Deferring to %.5f",
+                freeze_ceiling,
+            )
+            sl_price = _normalize(freeze_ceiling)
+
+    return sl_price, tp_price
+
+
+def send_entry(
+    symbol: str,
+    direction: str,
+    volume: float,
+    comment: str,
+    sl_price: float,
+    tp_price: float,
+    dryrun: bool = False,
+) -> Optional[mt5.OrderSendResult]:
+    """Submit a market order with attached protective stops."""
+    si = mt5.symbol_info(symbol)
+    if si is None:
+        raise RuntimeError(f"Symbol info unavailable for {symbol}")
+
+    volume = _round_volume(si, volume)
+
+    direction = direction.upper()
+    order_type = mt5.ORDER_TYPE_BUY if direction == "LONG" else mt5.ORDER_TYPE_SELL
+
+    tick = mt5.symbol_info_tick(symbol)
+    if tick is None:
+        raise RuntimeError(f"Symbol tick unavailable for {symbol}")
+
+    price = float(tick.ask if order_type == mt5.ORDER_TYPE_BUY else tick.bid)
+    sl_price, tp_price = make_legal_sl_tp(direction, price, sl_price, tp_price, symbol)
+
+    request = {
+        "action": mt5.TRADE_ACTION_DEAL,
+        "symbol": symbol,
+        "volume": volume,
+        "type": order_type,
+        "price": price,
+        "sl": sl_price,
+        "tp": tp_price,
+        "deviation": 20,
+        "comment": comment,
+        "type_filling": mt5.ORDER_FILLING_FOK,
+    }
+
+    logger.info(
+        "[BROKER] Sending order: dir=%s volume=%.2f price=%.5f sl=%.5f tp=%.5f dryrun=%s",
+        direction,
+        volume,
+        price,
+        sl_price,
+        tp_price,
+        dryrun,
+    )
+
+    if dryrun:
+        return None
+
+    result = mt5.order_send(request)
+    if result is None:
+        logger.error("[BROKER] order_send returned None")
+        return None
+
+    if result.retcode != mt5.TRADE_RETCODE_DONE:
+        logger.error("[BROKER] Order failed: retcode=%s comment=%s", result.retcode, result.comment)
+    else:
+        logger.info("[BROKER] Order placed. ticket=%s", result.order)
+    return result
+
+
+def modify_stop_to_breakeven(ticket: int, symbol: str, dryrun: bool = False) -> bool:
+    positions = mt5.positions_get(ticket=ticket)
+    if not positions:
+        logger.warning("[BROKER] No position found for ticket %s", ticket)
+        return False
+
+    pos = positions[0]
+    direction = "LONG" if pos.type == mt5.POSITION_TYPE_BUY else "SHORT"
+    current_sl = float(pos.sl)
+    breakeven_price = float(pos.price_open)
+    if direction == "LONG" and current_sl >= breakeven_price:
+        logger.info("[BROKER] Breakeven SL already in place for ticket %s", ticket)
+        return True
+    if direction == "SHORT" and (current_sl <= breakeven_price and current_sl != 0.0):
+        logger.info("[BROKER] Breakeven SL already in place for ticket %s", ticket)
+        return True
+
+    _, tp = make_legal_sl_tp(direction, pos.price_open, breakeven_price, pos.tp or 0.0, symbol)
+    sl, _ = make_legal_sl_tp(direction, pos.price_open, breakeven_price, tp, symbol)
+
+    request = {
+        "action": mt5.TRADE_ACTION_SLTP,
+        "position": ticket,
+        "symbol": symbol,
+        "sl": sl,
+        "tp": pos.tp,
+        "comment": "breakeven",
+    }
+
+    logger.info("[BROKER] Moving SL to breakeven for ticket=%s sl=%.5f", ticket, sl)
+
+    if dryrun:
+        return True
+
+    result = mt5.order_send(request)
+    if result is None:
+        logger.error("[BROKER] Breakeven modification failed (None)")
+        return False
+
+    if result.retcode not in {mt5.TRADE_RETCODE_DONE, mt5.TRADE_RETCODE_NO_CHANGES}:
+        logger.error(
+            "[BROKER] Breakeven modification failed: retcode=%s comment=%s",
+            result.retcode,
+            result.comment,
+        )
+        return False
+
+    return True
+
+
+def trail_stop(ticket: int, trail_price: float, symbol: str, dryrun: bool = False) -> bool:
+    """Trail the stop for a position while respecting freeze levels."""
+    positions = mt5.positions_get(ticket=ticket)
+    if not positions:
+        logger.warning("[BROKER] No position found for trailing ticket %s", ticket)
+        return False
+
+    pos = positions[0]
+    direction = "LONG" if pos.type == mt5.POSITION_TYPE_BUY else "SHORT"
+    current_sl = float(pos.sl)
+    desired_sl = float(trail_price)
+
+    if direction == "LONG" and current_sl != 0.0 and desired_sl <= current_sl:
+        logger.debug("[BROKER] Trail not applied (long). desired=%.5f current=%.5f", desired_sl, current_sl)
+        return False
+    if direction == "SHORT" and current_sl != 0.0 and desired_sl >= current_sl:
+        logger.debug("[BROKER] Trail not applied (short). desired=%.5f current=%.5f", desired_sl, current_sl)
+        return False
+
+    sl, tp = make_legal_sl_tp(direction, pos.price_open, desired_sl, pos.tp or 0.0, symbol)
+
+    if direction == "LONG" and sl <= current_sl:
+        logger.debug("[BROKER] Adjusted SL is not higher for long trail. sl=%.5f current=%.5f", sl, current_sl)
+        return False
+    if direction == "SHORT" and (current_sl == 0.0 or sl >= current_sl):
+        logger.debug("[BROKER] Adjusted SL is not lower for short trail. sl=%.5f current=%.5f", sl, current_sl)
+        return False
+
+    request = {
+        "action": mt5.TRADE_ACTION_SLTP,
+        "position": ticket,
+        "symbol": symbol,
+        "sl": sl,
+        "tp": pos.tp,
+        "comment": "trail",
+    }
+
+    logger.info("[BROKER] Trailing SL for ticket=%s to %.5f", ticket, sl)
+
+    if dryrun:
+        return True
+
+    result = mt5.order_send(request)
+    if result is None:
+        logger.error("[BROKER] Trail modification failed (None)")
+        return False
+
+    if result.retcode not in {mt5.TRADE_RETCODE_DONE, mt5.TRADE_RETCODE_NO_CHANGES}:
+        logger.error("[BROKER] Trail modification failed: retcode=%s comment=%s", result.retcode, result.comment)
+        return False
+
+    return True
+
+
+def close_position(ticket: int, symbol: str, dryrun: bool = False) -> bool:
+    positions = mt5.positions_get(ticket=ticket)
+    if not positions:
+        logger.warning("[BROKER] No position to close for ticket %s", ticket)
+        return False
+
+    pos = positions[0]
+    order_type = mt5.ORDER_TYPE_SELL if pos.type == mt5.POSITION_TYPE_BUY else mt5.ORDER_TYPE_BUY
+    tick = mt5.symbol_info_tick(symbol)
+    if tick is None:
+        raise RuntimeError(f"Symbol tick unavailable for {symbol}")
+
+    price = float(tick.bid if order_type == mt5.ORDER_TYPE_SELL else tick.ask)
+
+    request = {
+        "action": mt5.TRADE_ACTION_DEAL,
+        "symbol": symbol,
+        "position": ticket,
+        "volume": pos.volume,
+        "type": order_type,
+        "price": price,
+        "deviation": 20,
+        "comment": "close",
+    }
+
+    logger.info("[BROKER] Closing ticket=%s at price %.5f", ticket, price)
+
+    if dryrun:
+        return True
+
+    result = mt5.order_send(request)
+    if result is None:
+        logger.error("[BROKER] Close order failed (None)")
+        return False
+
+    if result.retcode != mt5.TRADE_RETCODE_DONE:
+        logger.error("[BROKER] Close order failed: retcode=%s comment=%s", result.retcode, result.comment)
+        return False
+
+    return True
+
+
+def get_open_positions(symbol: str):
+    return mt5.positions_get(symbol=symbol)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,29 @@
+CFG = {
+    "SYMBOL": "XAUUSDm",
+    # session/risk
+    "RISK_PCT_PER_TRADE": 0.0075,
+    "DAILY_MAX_DD_PCT": 6,
+    "DAILY_TARGET_PCT": 4,
+    "MAX_TRADES_PER_DAY": 30,
+    # spread & regime gates
+    "SPREAD_POINTS_BASE_CAP": 190,
+    "ADX_TREND_MIN": 25,
+    "ADX_MICRO_MIN": 14,
+    "DONCHIAN_LKB": 14,
+    "EMA_FAST": 13,
+    "EMA_SLOW": 34,
+    # volatility targets (ATR in price units)
+    "ATR_PERIOD": 14,
+    "ATR_MIN": 0.8,
+    "SL_ATR_MULT": 1.1,
+    "TP_R_MULT": 1.6,
+    # management
+    "BE_TRIGGER_R": 0.5,
+    "TRAIL_AFTER_R": 1.0,
+    "TRAIL_ATR_MULT": 0.8,
+    # exposure
+    "ALLOW_SINGLE_HEDGE": False,
+    "MAX_CONCURRENT_POS": 1,
+    # cadence
+    "ENTRY_COOLDOWN_SEC": 10,
+}

--- a/filters.py
+++ b/filters.py
@@ -1,0 +1,172 @@
+"""Indicator and regime filters for the execution bot."""
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+REGIME_TREND_LONG = "TREND_LONG"
+REGIME_TREND_SHORT = "TREND_SHORT"
+REGIME_UNSURE = "UNSURE"
+
+
+def _ema(values: np.ndarray, period: int) -> Optional[float]:
+    if period <= 0 or len(values) < period:
+        return None
+    multiplier = 2 / (period + 1.0)
+    ema = values[0]
+    for price in values[1:]:
+        ema = (price - ema) * multiplier + ema
+    return float(ema)
+
+
+def calculate_atr(rates: np.ndarray, period: int) -> Optional[float]:
+    if len(rates) < period + 1:
+        return None
+
+    highs = rates["high"].astype(float)
+    lows = rates["low"].astype(float)
+    closes = rates["close"].astype(float)
+
+    tr = np.maximum.reduce([
+        highs[1:] - lows[1:],
+        np.abs(highs[1:] - closes[:-1]),
+        np.abs(lows[1:] - closes[:-1]),
+    ])
+
+    atr = tr[:period].mean()
+    for value in tr[period:]:
+        atr = (atr * (period - 1) + value) / period
+    return float(atr)
+
+
+def calculate_adx(rates: np.ndarray, period: int) -> Optional[float]:
+    if len(rates) < period + 1:
+        return None
+
+    highs = rates["high"].astype(float)
+    lows = rates["low"].astype(float)
+    closes = rates["close"].astype(float)
+
+    up_move = highs[1:] - highs[:-1]
+    down_move = lows[:-1] - lows[1:]
+
+    plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
+    minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
+
+    tr_components = np.maximum.reduce([
+        highs[1:] - lows[1:],
+        np.abs(highs[1:] - closes[:-1]),
+        np.abs(lows[1:] - closes[:-1]),
+    ])
+
+    atr = tr_components[:period].sum()
+    plus_dm_sum = plus_dm[:period].sum()
+    minus_dm_sum = minus_dm[:period].sum()
+
+    adx_values = []
+    for i in range(period, len(tr_components)):
+        atr = atr - atr / period + tr_components[i]
+        plus_dm_sum = plus_dm_sum - plus_dm_sum / period + plus_dm[i]
+        minus_dm_sum = minus_dm_sum - minus_dm_sum / period + minus_dm[i]
+
+        plus_di = 100 * (plus_dm_sum / atr if atr else 0)
+        minus_di = 100 * (minus_dm_sum / atr if atr else 0)
+        dx = 100 * (abs(plus_di - minus_di) / max(plus_di + minus_di, 1e-9))
+        adx_values.append(dx)
+
+    if not adx_values:
+        return None
+
+    adx = adx_values[0]
+    for value in adx_values[1:]:
+        adx = (adx * (period - 1) + value) / period
+    return float(adx)
+
+
+def donchian_channels(highs: np.ndarray, lows: np.ndarray, lookback: int) -> Tuple[float, float]:
+    if lookback <= 0 or len(highs) < lookback or len(lows) < lookback:
+        lookback = min(len(highs), len(lows))
+    window_high = highs[-lookback:]
+    window_low = lows[-lookback:]
+    return float(window_high.max()), float(window_low.min())
+
+
+def market_state(rates: np.ndarray, cfg: Dict) -> Dict[str, Optional[float]]:
+    period = cfg["ATR_PERIOD"]
+    atr = calculate_atr(rates, period)
+    adx = calculate_adx(rates, period)
+    if atr is None or adx is None:
+        return {
+            "regime": REGIME_UNSURE,
+            "atr": atr,
+            "adx": adx,
+            "ema_fast": None,
+            "ema_slow": None,
+            "donchian_high": None,
+            "donchian_low": None,
+            "signal": None,
+            "size_factor": 0.0,
+        }
+
+    if atr < cfg["ATR_MIN"]:
+        return {
+            "regime": REGIME_UNSURE,
+            "atr": atr,
+            "adx": adx,
+            "ema_fast": None,
+            "ema_slow": None,
+            "donchian_high": None,
+            "donchian_low": None,
+            "signal": None,
+            "size_factor": 0.0,
+        }
+
+    closes = rates["close"].astype(float)
+    highs = rates["high"].astype(float)
+    lows = rates["low"].astype(float)
+
+    ema_fast = _ema(closes[-cfg["EMA_FAST"] * 2 :], cfg["EMA_FAST"])
+    ema_slow = _ema(closes[-cfg["EMA_SLOW"] * 2 :], cfg["EMA_SLOW"])
+
+    donchian_high = None
+    donchian_low = None
+    regime = REGIME_UNSURE
+    signal = None
+    size_factor = 0.0
+
+    if ema_fast is not None and ema_slow is not None:
+        donchian_high, donchian_low = donchian_channels(highs, lows, cfg["DONCHIAN_LKB"])
+        price = closes[-1]
+
+        if adx >= cfg["ADX_TREND_MIN"]:
+            if ema_fast > ema_slow and price > donchian_high:
+                regime = REGIME_TREND_LONG
+                signal = "LONG"
+                size_factor = 1.0
+            elif ema_fast < ema_slow and price < donchian_low:
+                regime = REGIME_TREND_SHORT
+                signal = "SHORT"
+                size_factor = 1.0
+        elif cfg["ADX_MICRO_MIN"] <= adx < cfg["ADX_TREND_MIN"]:
+            half_atr = 0.5 * atr
+            if ema_fast > ema_slow and 0 <= donchian_high - price <= half_atr:
+                regime = REGIME_TREND_LONG
+                signal = "LONG"
+                size_factor = 0.5
+            elif ema_fast < ema_slow and 0 <= price - donchian_low <= half_atr:
+                regime = REGIME_TREND_SHORT
+                signal = "SHORT"
+                size_factor = 0.5
+    return {
+        "regime": regime,
+        "atr": atr,
+        "adx": adx,
+        "ema_fast": ema_fast,
+        "ema_slow": ema_slow,
+        "donchian_high": donchian_high if 'donchian_high' in locals() else None,
+        "donchian_low": donchian_low if 'donchian_low' in locals() else None,
+        "signal": signal,
+        "size_factor": size_factor,
+    }

--- a/main.py
+++ b/main.py
@@ -1,0 +1,365 @@
+"""Main orchestration loop for the MetaTrader 5 execution bot."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+import statistics
+import time
+from collections import deque
+from typing import Dict, List, Optional
+
+import MetaTrader5 as mt5
+import numpy as np
+
+from broker import (
+    close_position,
+    get_open_positions,
+    make_legal_sl_tp,
+    modify_stop_to_breakeven,
+    send_entry,
+    trail_stop,
+)
+from config import CFG
+from filters import REGIME_UNSURE, market_state
+from risk import (
+    DailyState,
+    STOP_LOSS,
+    STOP_MAX_TRADES,
+    STOP_NONE,
+    STOP_TARGET,
+    daily_stop,
+    lots_for_risk,
+    manage_open_trade,
+    max_trades_reached,
+    trade_risk_dollars,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class TradingBot:
+    def __init__(self, cfg: Dict, dryrun: bool = False) -> None:
+        self.cfg = cfg
+        self.symbol = cfg["SYMBOL"]
+        self.dryrun = dryrun
+        self.daily_state = DailyState()
+        self.last_day = None
+        self.spreads = deque(maxlen=120)
+        self.timeframe = mt5.TIMEFRAME_M5
+
+    def initialize(self) -> None:
+        if not mt5.initialize():
+            raise RuntimeError("Failed to initialize MetaTrader5")
+        if not mt5.symbol_select(self.symbol, True):
+            raise RuntimeError(f"Unable to select symbol {self.symbol}")
+        info = mt5.account_info()
+        if info is None:
+            raise RuntimeError("Account info unavailable")
+        self._reset_daily(info.equity)
+
+    def _reset_daily(self, equity: float) -> None:
+        today = dt.date.today()
+        self.last_day = today
+        self.daily_state.reset(equity)
+        logger.info("[INIT] Daily counters reset. equity=%.2f", equity)
+
+    def _update_daily(self, equity: float) -> None:
+        today = dt.date.today()
+        if self.last_day != today:
+            self._reset_daily(equity)
+        self.daily_state.update_equity(equity)
+
+    def _dynamic_spread_cap(self) -> int:
+        base = self.cfg["SPREAD_POINTS_BASE_CAP"]
+        if len(self.spreads) < 5:
+            return base
+        median_spread = statistics.median(self.spreads)
+        cap = max(120, min(240, int(median_spread * 2.2)))
+        return max(cap, base)
+
+    def _fetch_rates(self, count: int = 200) -> Optional[np.ndarray]:
+        rates = mt5.copy_rates_from_pos(self.symbol, self.timeframe, 0, count)
+        if rates is None or len(rates) == 0:
+            return None
+        return rates
+
+    def step(self) -> None:
+        account = mt5.account_info()
+        if account is None:
+            logger.error("[STATE] Account info unavailable; skipping step")
+            return
+
+        self._update_daily(account.equity)
+
+        tick = mt5.symbol_info_tick(self.symbol)
+        if tick is None:
+            logger.error("[STATE] Tick unavailable; skipping step")
+            return
+
+        symbol_info = mt5.symbol_info(self.symbol)
+        if symbol_info is None:
+            logger.error("[STATE] Symbol info unavailable; skipping step")
+            return
+
+        point = symbol_info.point
+        spread_points = (tick.ask - tick.bid) / point if point else 0.0
+        self.spreads.append(spread_points)
+        spread_cap = self._dynamic_spread_cap()
+
+        rates = self._fetch_rates()
+        if rates is None:
+            logger.error("[STATE] Failed to fetch rates; skipping step")
+            return
+
+        market = market_state(rates, self.cfg)
+        atr = market.get("atr")
+        adx = market.get("adx")
+        regime = market.get("regime", REGIME_UNSURE)
+
+        logger.info(
+            "[STATE] regime=%s spread=%.1f/%.0f ATR=%s ADX=%s",
+            regime,
+            spread_points,
+            spread_cap,
+            f"{atr:.2f}" if atr is not None else "--",
+            f"{adx:.1f}" if adx is not None else "--",
+        )
+
+        daily_reason = daily_stop(
+            self.daily_state.change_pct,
+            self.daily_state.dd_pct,
+            self.cfg["DAILY_TARGET_PCT"],
+            self.cfg["DAILY_MAX_DD_PCT"],
+        )
+        trades_limit_hit = max_trades_reached(self.daily_state.trades, self.cfg["MAX_TRADES_PER_DAY"])
+
+        daily_label = daily_reason
+        if trades_limit_hit and daily_label == STOP_NONE:
+            daily_label = STOP_MAX_TRADES
+
+        logger.info(
+            "[RISK] equity=%.2f trades_today=%s/%s daily_stop=%s",
+            account.equity,
+            self.daily_state.trades,
+            self.cfg["MAX_TRADES_PER_DAY"],
+            daily_label,
+        )
+
+        gate_reasons: List[str] = []
+        if atr is None:
+            gate_reasons.append("ATR unavailable")
+        elif atr < self.cfg["ATR_MIN"]:
+            gate_reasons.append("ATR<min")
+        if adx is None:
+            gate_reasons.append("ADX unavailable")
+        if spread_points > spread_cap:
+            gate_reasons.append("spread>cap")
+        if daily_reason in {STOP_LOSS, STOP_TARGET}:
+            gate_reasons.append(f"daily {daily_reason.lower()}")
+        if trades_limit_hit:
+            gate_reasons.append("daily max trades")
+
+        logger.info(
+            "[GATE] %s",
+            ", ".join(gate_reasons) if gate_reasons else "clear",
+        )
+
+        positions = get_open_positions(self.symbol) or []
+
+        if positions:
+            self._manage_positions(positions, atr, tick)
+            return
+
+        # Reset hedge allowance when flat
+        self.daily_state.hedge_used = False
+
+        if gate_reasons:
+            return
+
+        signal = market.get("signal")
+        size_factor = market.get("size_factor", 0.0)
+        if signal not in {"LONG", "SHORT"}:
+            logger.info("[GATE] no_trade: regime UNSURE")
+            return
+
+        if size_factor <= 0:
+            logger.info("[GATE] no_trade: size factor 0")
+            return
+
+        if self.cfg["MAX_CONCURRENT_POS"] <= 0:
+            logger.info("[GATE] no_trade: max concurrent 0")
+            return
+
+        stop_distance = self.cfg["SL_ATR_MULT"] * atr
+        tp_distance = stop_distance * self.cfg["TP_R_MULT"]
+
+        risk_pct = self.cfg["RISK_PCT_PER_TRADE"] * size_factor
+        try:
+            lots = lots_for_risk(self.symbol, account.equity, risk_pct, stop_distance)
+        except ValueError as exc:
+            logger.error("[ENTRY] sizing_error: %s", exc)
+            return
+        if lots <= 0:
+            logger.info("[GATE] no_trade: lot size<=0")
+            return
+
+        entry_price = float(tick.ask if signal == "LONG" else tick.bid)
+        if signal == "LONG":
+            sl_price = entry_price - stop_distance
+            tp_price = entry_price + tp_distance
+        else:
+            sl_price = entry_price + stop_distance
+            tp_price = entry_price - tp_distance
+
+        sl_price, tp_price = make_legal_sl_tp(signal, entry_price, sl_price, tp_price, self.symbol)
+        r_value = trade_risk_dollars(self.symbol, lots, stop_distance)
+
+        logger.info(
+            "[ENTRY] side=%s lot=%.2f price=%.3f SL=%.3f TP=%.3f R=$%.2f",
+            signal,
+            lots,
+            entry_price,
+            sl_price,
+            tp_price,
+            r_value,
+        )
+
+        if not self.dryrun:
+            result = send_entry(
+                self.symbol,
+                signal,
+                lots,
+                "bot_entry",
+                sl_price,
+                tp_price,
+                dryrun=False,
+            )
+            if result and result.retcode == mt5.TRADE_RETCODE_DONE:
+                self.daily_state.trades += 1
+        else:
+            logger.info("[ENTRY] dryrun active - order not sent")
+            self.daily_state.trades += 1
+
+    def _manage_positions(self, positions, atr: Optional[float], tick) -> None:
+        if atr is None or atr <= 0:
+            logger.info("[MX] ATR unavailable for management")
+            return
+
+        for pos in positions:
+            direction = "LONG" if pos.type == mt5.POSITION_TYPE_BUY else "SHORT"
+            price = float(tick.bid if direction == "LONG" else tick.ask)
+            stop_distance = (
+                pos.price_open - pos.sl
+                if direction == "LONG"
+                else pos.sl - pos.price_open
+            )
+            if stop_distance <= 0:
+                stop_distance = self.cfg["SL_ATR_MULT"] * atr
+
+            pnl_dollars = float(pos.profit)
+            r_value = trade_risk_dollars(self.symbol, pos.volume, stop_distance)
+            decision = manage_open_trade(
+                pnl_dollars,
+                r_value,
+                self.cfg["BE_TRIGGER_R"],
+                self.cfg["TRAIL_AFTER_R"],
+            )
+            r_multiple = pnl_dollars / r_value if r_value else 0.0
+
+            logger.info(
+                "[MX] ticket=%s action=%s r_mult=%.2f pnl=$%.2f",
+                pos.ticket,
+                decision,
+                r_multiple,
+                pnl_dollars,
+            )
+
+            if decision == "BREAKEVEN_SL":
+                modify_stop_to_breakeven(pos.ticket, self.symbol, dryrun=self.dryrun)
+            elif decision == "TRAIL":
+                trail_distance = self.cfg["TRAIL_ATR_MULT"] * atr
+                if direction == "LONG":
+                    candidate_sl = max(float(pos.sl), price - trail_distance)
+                else:
+                    candidate_sl = min(float(pos.sl) if pos.sl else price + trail_distance, price + trail_distance)
+                trail_stop(pos.ticket, candidate_sl, self.symbol, dryrun=self.dryrun)
+            elif decision == "CUT_OR_HEDGE":
+                self._handle_cut_or_hedge(pos, atr, price)
+
+    def _handle_cut_or_hedge(self, pos, atr: float, price: float) -> None:
+        direction = "LONG" if pos.type == mt5.POSITION_TYPE_BUY else "SHORT"
+        if self.cfg["ALLOW_SINGLE_HEDGE"] and not self.daily_state.hedge_used:
+            hedge_dir = "SHORT" if direction == "LONG" else "LONG"
+            stop_distance = self.cfg["SL_ATR_MULT"] * atr
+            tp_distance = stop_distance * self.cfg["TP_R_MULT"]
+            entry_price = price
+            if hedge_dir == "LONG":
+                sl_price = entry_price - stop_distance
+                tp_price = entry_price + tp_distance
+            else:
+                sl_price = entry_price + stop_distance
+                tp_price = entry_price - tp_distance
+
+            sl_price, tp_price = make_legal_sl_tp(hedge_dir, entry_price, sl_price, tp_price, self.symbol)
+            logger.info(
+                "[HEDGE] placing hedge dir=%s lot=%.2f price=%.3f SL=%.3f TP=%.3f",
+                hedge_dir,
+                pos.volume,
+                entry_price,
+                sl_price,
+                tp_price,
+            )
+            if not self.dryrun:
+                send_entry(
+                    self.symbol,
+                    hedge_dir,
+                    pos.volume,
+                    "hedge",
+                    sl_price,
+                    tp_price,
+                    dryrun=False,
+                )
+            self.daily_state.hedge_used = True
+        else:
+            logger.info("[HEDGE] closing losing leg ticket=%s", pos.ticket)
+            close_position(pos.ticket, self.symbol, dryrun=self.dryrun)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the MT5 execution bot")
+    parser.add_argument("--dryrun", action="store_true", help="Simulate without sending orders")
+    parser.add_argument("--once", action="store_true", help="Run a single iteration and exit")
+    return parser.parse_args()
+
+
+def setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    setup_logging()
+
+    bot = TradingBot(CFG, dryrun=args.dryrun)
+    bot.initialize()
+
+    logger.info("[INIT] Bot started. dryrun=%s", args.dryrun)
+
+    try:
+        while True:
+            bot.step()
+            if args.once:
+                break
+            time.sleep(CFG["ENTRY_COOLDOWN_SEC"])
+    finally:
+        mt5.shutdown()
+        logger.info("[SHUTDOWN] MT5 connection closed")
+
+
+if __name__ == "__main__":
+    main()

--- a/risk.py
+++ b/risk.py
@@ -1,0 +1,134 @@
+"""Risk controls and position sizing helpers."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+import MetaTrader5 as mt5
+
+
+logger = logging.getLogger(__name__)
+
+STOP_NONE = "NONE"
+STOP_LOSS = "STOP_LOSS"
+STOP_TARGET = "STOP_TARGET"
+STOP_MAX_TRADES = "MAX_TRADES"
+
+
+@dataclass
+class DailyState:
+    start_equity: float = 0.0
+    peak_equity: float = 0.0
+    trough_equity: float = 0.0
+    last_equity: float = 0.0
+    trades: int = 0
+    hedge_used: bool = False
+
+    def reset(self, equity: float) -> None:
+        self.start_equity = equity
+        self.peak_equity = equity
+        self.trough_equity = equity
+        self.last_equity = equity
+        self.trades = 0
+        self.hedge_used = False
+
+    def update_equity(self, equity: float) -> None:
+        self.peak_equity = max(self.peak_equity, equity)
+        self.trough_equity = min(self.trough_equity, equity)
+        self.last_equity = equity
+
+    @property
+    def change_pct(self) -> float:
+        if self.start_equity <= 0:
+            return 0.0
+        return ((self.last_equity or self.start_equity) - self.start_equity) / self.start_equity * 100.0
+
+    @property
+    def dd_pct(self) -> float:
+        if self.start_equity <= 0:
+            return 0.0
+        return (self.trough_equity - self.start_equity) / self.start_equity * 100.0
+
+
+def _snap_to_step(volume: float, step: float) -> float:
+    step = max(step, 1e-8)
+    return round(volume / step) * step
+
+
+def lots_for_risk(symbol: str, equity: float, risk_pct: float, stop_distance_price: float) -> float:
+    si = mt5.symbol_info(symbol)
+    if si is None:
+        raise RuntimeError(f"Symbol info unavailable for {symbol}")
+
+    tick_value = getattr(si, "trade_tick_value", 0.0) or None
+    tick_size = getattr(si, "trade_tick_size", 0.0) or None
+    if tick_value and tick_size:
+        dollars_per_price = tick_value / tick_size
+    else:
+        dollars_per_price = si.trade_contract_size * si.point
+
+    stop_distance_price = abs(stop_distance_price)
+    if stop_distance_price <= 0:
+        raise ValueError("Stop distance must be positive for sizing")
+
+    dollars_per_lot_at_stop = stop_distance_price * dollars_per_price
+    acct_risk = equity * risk_pct
+    raw_lots = acct_risk / max(1e-9, dollars_per_lot_at_stop)
+
+    min_vol = si.volume_min
+    max_vol = si.volume_max
+    raw_lots = max(min_vol, min(max_vol, raw_lots))
+    snapped = _snap_to_step(raw_lots, si.volume_step)
+    precision = getattr(si, "volume_precision", 2)
+    return round(max(min_vol, min(max_vol, snapped)), precision)
+
+
+def dollars_per_price_unit(symbol: str) -> float:
+    si = mt5.symbol_info(symbol)
+    if si is None:
+        raise RuntimeError(f"Symbol info unavailable for {symbol}")
+
+    tick_value = getattr(si, "trade_tick_value", 0.0) or None
+    tick_size = getattr(si, "trade_tick_size", 0.0) or None
+    if tick_value and tick_size:
+        return tick_value / tick_size
+    return si.trade_contract_size * si.point
+
+
+def trade_risk_dollars(symbol: str, volume: float, stop_distance_price: float) -> float:
+    return abs(stop_distance_price) * dollars_per_price_unit(symbol) * volume
+
+
+Decision = Literal["TRAIL", "BREAKEVEN_SL", "CUT_OR_HEDGE", "HOLD"]
+
+
+def manage_open_trade(
+    pnl_dollars: float,
+    r_value_dollars: float,
+    be_trigger_r: float,
+    trail_after_r: float,
+) -> Decision:
+    if r_value_dollars <= 0:
+        return "HOLD"
+
+    r_multiple = pnl_dollars / r_value_dollars
+    if r_multiple >= trail_after_r:
+        return "TRAIL"
+    if r_multiple >= be_trigger_r:
+        return "BREAKEVEN_SL"
+    if r_multiple <= -1.0:
+        return "CUT_OR_HEDGE"
+    return "HOLD"
+
+
+def daily_stop(change_pct: float, dd_pct: float, target_pct: float, max_dd_pct: float) -> str:
+    if dd_pct <= -max_dd_pct:
+        return STOP_LOSS
+    if change_pct >= target_pct:
+        return STOP_TARGET
+    return STOP_NONE
+
+
+def max_trades_reached(count: int, limit: int) -> bool:
+    return count >= limit


### PR DESCRIPTION
## Summary
- add configuration constants for ATR-sized stops, risk caps, and trading cadence
- implement broker utilities that attach legal SL/TP on entry and support breakeven and trailing stop management
- add risk, indicator, and orchestration modules to size positions, gate entries, and manage trades with detailed logging and dry-run support

## Testing
- python -m compileall config.py broker.py risk.py filters.py main.py

------
https://chatgpt.com/codex/tasks/task_e_6909e10319f4832c8d880d578a02fa79